### PR TITLE
Allow running this app locally, against a local GemFire

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ build/
 nbbuild/
 dist/
 nbdist/
-.nb-gradle/.*.swp
+.nb-gradle/
+.*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ build/
 nbbuild/
 dist/
 nbdist/
-.nb-gradle/
+.nb-gradle/.*.swp

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ This app demonstrates a few of **Pivotal Cloud Cache’s (PCC)** interesting fea
 Steps:
 
 1. Build the Spring Boot Executable JAR file to deploy to PCF using the `./gradlew build` command.
-2. Call the `cf push` command to push the Spring Boot application to PCF. A PCF `manifest.yml` file already exists in the project root directory.
-3. Bind the Spring Boot application to a *Pivotal Cloud Cache (PCC)* service instance using the command `cf bind-service APP_NAME SERVICE_INSTANCE [-c PARAMETERS_AS_JSON]`.
-If a PCC service instance has not yet been created, then create the service using `cf create-service p-cloudcache PLAN_NAME SERVICE_INSTANCE`.
+1. Create the regions (see below)
+1. Call the `cf push --no-start` command to push the Spring Boot application to PCF. A PCF `manifest.yml` file already exists in the project root directory.
+1. Bind the Spring Boot application to a *Pivotal Cloud Cache (PCC)* service instance using the command `cf bind-service APP_NAME SERVICE_INSTANCE [-c PARAMETERS_AS_JSON]`. If a PCC service instance has not yet been created, then create the service using `cf create-service p-cloudcache PLAN_NAME SERVICE_INSTANCE`.
+1. Start the app: `cf start pizza-store`
 
 Once application is successfully deployed, hit the REST API endpoint `<url>/ping` and you should see a 200-OK response code with a response of "**PONG!**".
 
@@ -22,18 +23,31 @@ Before starting the Spring Boot application, you will need to create the Regions
 
 After standing up the PCC service and creating a service key, connect to the cluster via _Gfsh_.
 
-`create region --name=Pizza --type=PARTITION_REDUNDANT`
-`create region --name=Name --type=PARTITION_REDUNDANT`
+`gfsh>create region --name=Pizza --type=PARTITION_REDUNDANT`
+`gfsh>create region --name=Name --type=PARTITION_REDUNDANT`
+
+## How to run locally, against a GemFire running on your own computer
+1. Build the Spring Boot Executable JAR: `$ ./gradlew clean build`
+1. Start the GemFire shell: `$ gfsh`
+1. Start a locator: `gfsh>start locator --name=locator1`
+1. Start a server: `gfsh>start server --name=server1 --server-port=40411`
+1. Create the GemFire regions:
+   ```
+   gfsh>create region --name=Pizza --type=PARTITION_REDUNDANT`
+   gfsh>create region --name=Name --type=PARTITION_REDUNDANT`
+   ```
+1. Set up the environment: `$ export VCAP_APPLICATION=$( cat ./VCAP_APPLICATION.json ) ; export VCAP_SERVICES=$( cat ./VCAP_SERVICES.json )`
+1. Start the app: `$ java -jar ./build/libs/PCC-Sample-App-PizzaStore-1.0.0-SNAPSHOT.jar`
 
 ## About the Sample Spring Boot Application
 
 *Pivotal Cloud Cache (PCC)* is a high-performance, high-availability caching layer for *Pivotal Cloud Foundry (PCF)*.
-This is sample Spring Boot application uses PCC as a caching provider and event source.
+This is a sample Spring Boot application using PCC as a caching provider and event source.
 
 This Spring Boot application implements a Pizza Store that can be used to order `Pizzas` with different sauces and toppings.
 
-All `Pizza` orders are stored in the data servers running in the PCC cluster. The app uses _Spring Data Repositories_ to store
-and access, or query data stored in PCC.
+All `Pizza` orders are stored in the data servers running in the PCC cluster. The app uses _Spring Data Repositories_ to store,
+access, or query data stored in PCC.
 
 The application models 2 types of Objects that will be stored in PCC.
 
@@ -41,14 +55,13 @@ The application models 2 types of Objects that will be stored in PCC.
  - Pizza
 
 > NOTE: `Regions` in PCC/Pivotal GemFire terminology are analogous to a RDBMS table,
-but are a Key/Value store, and in fact, implement `java.util.concurrent.ConcurrentMap`.
+but are a Key/Value store implementing `java.util.concurrent.ConcurrentMap`.
 
 Both application domain model objects use the Repository (DAO) pattern to write to,
 and access data from, PCC.
 
 The application leverages Spring Web MVC `Controllers` to expose data access operations
 you can perform over REST.
-
 
 #### REST API endpoints
 
@@ -63,11 +76,11 @@ when accessing this app from your Web browser.
 
  `curl -k https://cloudcache-pizza-store.cfapps.io/ping`
 
- * `GET /preheatOven` - Loads the "_Pizza_" `Region` wkith pre-baked pizzas that can be queried with `/pizzas`.
+ * `GET /preheatOven` - Loads the "_Pizza_" `Region` with pre-baked pizzas that can be queried with `/pizzas`.
  This REST API endpoint calls `Repository.save()` for each pre-baked `Pizza` and verifies the pizzas
- with the `Repository.findById(..)` on "_Pizza_" `Region` to verify that everything was setup properly.
- It creates 3 types of pizzas: a Plain Pizza with Tomato Sauce and Cheese Topping, a Alfredo, Chicken, Arugula Pizza
- and a Pesto Chicken Parmesan Pizza with Cherry Tomatoes.  Hungry yet, ;-).
+ with the `Repository.findById(..)` on the "_Pizza_" `Region` to verify that everything was setup properly.
+ It creates 3 types of pizzas: a _Plain Pizza with Tomato Sauce and Cheese Topping_, an _Alfredo, Chicken, Arugula Pizza_,
+ and a _Pesto Chicken Parmesan Pizza with Cherry Tomatoes_.  Hungry yet? ;-)
 
  * `GET /pizzas` - Lists the currently ordered pizzas, returning a JSON array containing `Pizza` objects.
  Returns "_No Pizzas Found_" if no pizzas have been baked.
@@ -80,7 +93,7 @@ when accessing this app from your Web browser.
  `curl -k https://cloudcache-pizza-store.cfapps.io/pizzas/plain`
 
  * `GET /pizzas/order/{name}\[?sauce=<sauce>\[&toppings=\<topping-1>,\<topping-2>,...,\<topping-N>]] - Bakes a `Pizza`
- of the users choosing with an optional `sauce` (defaults to `TOMATO`) and optional `toppings` (defaults to `CHEESE`)*[]:
+ of the user's choosing with an optional `sauce` (defaults to `TOMATO`) and optional `toppings` (defaults to `CHEESE`)*[]:
 
  `curl -k https://cloudcache-pizza-store.cfapps.io/pizzas/order/myCustomPizza?sauce=MARINARA&toppings=CHEESE,PEPPERONI,MUSHROOM`
 
@@ -92,19 +105,19 @@ when accessing this app from your Web browser.
 
 This Spring Boot application registers 2 different **Continuous Queries** on the "_Pizza_" `Region`.
 
-Whenever any Pizza is ordered, then the event is logged to `System.err`.
+When a Pizza is ordered, the event is logged to `System.err`.
 
-And, when any Pesto Pizza is ordered, then the CQ event with the name of the Pizza is written to the "_Name_" `Region`.
+When any **Pesto Pizza** is ordered, then the CQ event with the name of the Pizza is written to the "_Name_" `Region`.
 
-PCC/Pivotal GemFire supports the notion of **Continuous Query**, which means a developer can register interests in events.
-Interests are expressed with an OQL query on `Regions` contaning the data interests.  This is ideal since the developer
-can use complex criteria in a OQL query predicate with the exact data the developer is interested in receiving notifications for.
-Thus, when data event occurs matching the conditions expressed in the CQ query predicate, then an event will be returned with
-the data.
+PCC/Pivotal GemFire supports the notion of **Continuous Query**, which means a developer can register interest in events.
+Interest is expressed via an OQL query on `Regions` containing the data of interest.  This is ideal since the developer
+can use complex criteria in a OQL query predicate with the exact data they are interested in receiving notifications for.
+Thus, when a data event occurs matching the conditions expressed in the CQ query predicate, an event will be returned **with
+the data**.
 
 For more details on Pivotal GemFire CQ, see the GemFire [User Guide](http://gemfire.docs.pivotal.io/95/geode/developing/continuous_querying/chapter_overview.html).
 
-For more details on how to use Pivotal GemFire CQ in your Spring Boot applications see [here](https://docs.spring.io/spring-data/gemfire/docs/current/reference/html/#bootstrap-annotation-config-continuous-queries).
+Further detail on how to use Pivotal GemFire CQ in your Spring Boot applications are [here](https://docs.spring.io/spring-data/gemfire/docs/current/reference/html/#bootstrap-annotation-config-continuous-queries).
 
 #### Known Issues
 
@@ -112,7 +125,7 @@ For more details on how to use Pivotal GemFire CQ in your Spring Boot applicatio
     * If using the Gradle plugin, you will need to change the Spring Boot plug-in from `spring-boot` to `org.springframework.boot`.
     * If using Gradle, the version must be 4.2 or above.
 * _Spring Data for Pivotal GemFire_ makes it easy and quick to build highly-scalable, Spring-powered applications using Pivotal GemFire
-as a distributed data management platform. _Spring Data for GemFire_ 2.0.x uses Pivotal GemFire 9.1.1. If a different version is required,
+as a distributed data management platform. _Spring Data for GemFire_ 2.0.x uses **Pivotal GemFire 9.1.1**. If a different version is required,
 you must exclude the Pivotal GemFire library from Spring Data for Pivotal GemFire in your project build dependencies.
 When the Pivotal GemFire library is excluded, each required library must be explicitly specified.
 
@@ -130,8 +143,9 @@ Example `build.gradle`:
 ```
 
 * Finally, to realize the full potential and power of Pivotal GemFire or PCC in a Spring context, use the _Spring Boot for Pivotal GemFire_
-project...
+project.
 
 ```
   compile "org.springframework.geode:gemfire-spring-boot-starter:$springBootDataGemFireVersion"
 ```
+

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ After standing up the PCC service and creating a service key, connect to the clu
 1. Start the GemFire shell: `$ gfsh`
 1. Start a locator: `gfsh>start locator --name=locator1`
 1. Start a server: `gfsh>start server --name=server1 --server-port=40411`
+1. Configure PDX: `gfsh>configure pdx --disk-store=DEFAULT`
 1. Create the GemFire regions:
    ```
-   gfsh>create region --name=Pizza --type=PARTITION_REDUNDANT`
-   gfsh>create region --name=Name --type=PARTITION_REDUNDANT`
+   gfsh>create region --name=Pizza --type=PARTITION_PERSISTENT_OVERFLOW
+   gfsh>create region --name=Name --type=PARTITION_PERSISTENT_OVERFLOW
    ```
 1. Set up the environment: `$ export VCAP_APPLICATION=$( cat ./VCAP_APPLICATION.json ) ; export VCAP_SERVICES=$( cat ./VCAP_SERVICES.json )`
 1. Start the app: `$ java -jar ./build/libs/PCC-Sample-App-PizzaStore-1.0.0-SNAPSHOT.jar`

--- a/VCAP_APPLICATION.json
+++ b/VCAP_APPLICATION.json
@@ -1,0 +1,22 @@
+{
+  "application_id": "b6b8b253-0695-44a2-94c4-366e55fa48a3",
+  "application_name": "pizza-store",
+  "application_uris": [
+   "pizza-store.localhost.localdomain"
+  ],
+  "application_version": "ed0b6a90-d71e-4eaa-bf9a-ca5c55e32984",
+  "cf_api": "https://api.somepcf.org",
+  "limits": {
+   "disk": 1024,
+   "fds": 16384,
+   "mem": 1024
+  },
+  "name": "pizza-store",
+  "space_id": "1f63b79f-1332-4aed-8fa0-a2ff8e61f525",
+  "space_name": "development",
+  "uris": [
+   "pizza-store.localhost.localdomain"
+  ],
+  "users": null,
+  "version": "ed0b6a90-d71e-4eaa-bf9a-ca5c55e32984"
+}

--- a/VCAP_SERVICES.json
+++ b/VCAP_SERVICES.json
@@ -1,0 +1,54 @@
+{
+  "p-cloudcache": [
+   {
+    "binding_name": null,
+    "credentials": {
+     "distributed_system_id": "0",
+     "locators": [
+      "192.168.1.6[10334]"
+     ],
+     "urls": {
+      "gfsh": "https://cloudcache-ef3340f8-4e0b-4b79-bdd7-454cd5b87d4a.run.pcfbeta.io/gemfire/v1",
+      "pulse": "https://cloudcache-ef3340f8-4e0b-4b79-bdd7-454cd5b87d4a.run.pcfbeta.io/pulse"
+     },
+     "users": [
+      {
+       "password": "qr6nIz4FPrlAU8r9gICGg",
+       "roles": [
+        "developer"
+       ],
+       "username": "developer_yqfEY8XBb9EiE9wBpRhRSg"
+      },
+      {
+       "password": "qVbbEzkE9AhunHIfXt4tg",
+       "roles": [
+        "cluster_operator"
+       ],
+       "username": "cluster_operator_jmv7LKSXDR9gYalvUvX2Q"
+      }
+     ],
+     "wan": {
+      "sender_credentials": {
+       "active": {
+        "password": "8mzpPDW5KC8UJHVn7pnQ",
+        "username": "gateway_sender_SbrOkhDnCWiecDZgqiYkSg"
+       }
+      }
+     }
+    },
+    "instance_name": "pcc-retail",
+    "label": "p-cloudcache",
+    "name": "pcc-retail",
+    "plan": "extra-small",
+    "provider": null,
+    "syslog_drain_url": null,
+    "tags": [
+     "gemfire",
+     "cloudcache",
+     "database",
+     "pivotal"
+     ],
+    "volume_mounts": []
+   }
+  ]
+}


### PR DESCRIPTION
I found it useful to be able to run this app locally as I tried to figure it all out.  The one caveat with this PR is that the `/nukeAndPave` endpoint produces the following error in the Boot app:

```
[error 2018/07/03 11:13:36.092 EDT <http-nio-8080-exec-1> tid=0x26] Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is org.springframework.dao.DataAccessResourceFailureException: remote server on 192.168.1.6(SpringBootPivotalCloudCachePizzaStoreApplication:35647:loner):53190:3addab60:SpringBootPivotalCloudCachePizzaStoreApplication: : While performing a remote clear region; nested exception is org.apache.geode.cache.client.ServerOperationException: remote server on 192.168.1.6(SpringBootPivotalCloudCachePizzaStoreApplication:35647:loner):53190:3addab60:SpringBootPivotalCloudCachePizzaStoreApplication: : While performing a remote clear region] with root cause
java.lang.UnsupportedOperationException
	at org.apache.geode.internal.cache.PartitionedRegion.basicClear(PartitionedRegion.java:1964)
	at org.apache.geode.internal.cache.LocalRegion.basicBridgeClear(LocalRegion.java:9017)
	at org.apache.geode.internal.cache.tier.sockets.command.ClearRegion.cmdExecute(ClearRegion.java:126)
	at org.apache.geode.internal.cache.tier.sockets.BaseCommand.execute(BaseCommand.java:165)
	at org.apache.geode.internal.cache.tier.sockets.ServerConnection.doNormalMsg(ServerConnection.java:791)
	at org.apache.geode.internal.cache.tier.sockets.ServerConnection.doOneMessage(ServerConnection.java:922)
	at org.apache.geode.internal.cache.tier.sockets.ServerConnection.run(ServerConnection.java:1180)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at org.apache.geode.internal.cache.tier.sockets.AcceptorImpl$1$1.run(AcceptorImpl.java:523)
	at java.lang.Thread.run(Thread.java:748)
```

I'm hoping we can figure this one out together ...

Also, there are a few changes to the wording in the README, which I hope are alright.
