### PR TITLE
Update spring to 2.5.12 to address CVE-2022-22965

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.2</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>io.pivotal.cloudcache.sample</groupId>


### PR DESCRIPTION
[GF4TAS-498] Changes from 2.0.x to 2.1.x